### PR TITLE
fix: fix JSONDEcodeError exception

### DIFF
--- a/grafana_client/client.py
+++ b/grafana_client/client.py
@@ -1,7 +1,7 @@
 import niquests
 import niquests.auth
 from niquests import HTTPError, Timeout
-from requests.exceptions import JSONDecodeError
+from niquests.exceptions import JSONDecodeError
 
 DEFAULT_TIMEOUT: float = 5.0
 DEFAULT_SESSION_POOL_SIZE: int = 10


### PR DESCRIPTION
```
/home/vscode/.local/lib/python3.10/site-packages/grafana_client/elements/folder.py:87: in delete_folder
    return self.client.DELETE(path)
/home/vscode/.local/lib/python3.10/site-packages/grafana_client/client.py:218: in __request_runner
    return self._extract_from_response(r, accept_empty_json)
/home/vscode/.local/lib/python3.10/site-packages/grafana_client/client.py:187: in _extract_from_response
    return r.json()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Response HTTP/1.1 [200]>, kwargs = {}

    def json(self, **kwargs: typing.Any) -> typing.Any:
        r"""Returns the json-encoded content of a response, if any.
    
        :param \*\*kwargs: Optional arguments that ``json.loads`` takes.
        :raises requests.exceptions.JSONDecodeError: If the response body does not
            contain valid json or if content-type is not about json.
        """
    
        if (
            not self.content
            or "json" not in self.headers.get("content-type", "").lower()
        ):
>           raise RequestsJSONDecodeError(
                "response content is not JSON", self.text or "", 0
            )
E           niquests.exceptions.JSONDecodeError: response content is not JSON: line 1 column 1 (char 0)

/home/vscode/.local/lib/python3.10/site-packages/niquests/models.py:1513: JSONDecodeError
```